### PR TITLE
Initialize TaskFlow skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL="postgresql://taskflow:password@localhost:5432/taskflow"
+NEXTAUTH_SECRET="your-secret"
+NEXTAUTH_URL="http://localhost:3000"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+.env
+.env.local
+dist
+.DS_Store

--- a/app/(main)/board/[boardId]/page.tsx
+++ b/app/(main)/board/[boardId]/page.tsx
@@ -1,0 +1,15 @@
+import { notFound } from 'next/navigation';
+interface BoardPageProps {
+  params: { boardId: string };
+}
+
+export default function BoardPage({ params }: BoardPageProps) {
+  const { boardId } = params;
+  if (!boardId) return notFound();
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold">Board {boardId}</h2>
+      {/* Lists and cards will be displayed here */}
+    </div>
+  );
+}

--- a/app/(main)/dashboard/page.tsx
+++ b/app/(main)/dashboard/page.tsx
@@ -1,0 +1,8 @@
+export default function DashboardPage() {
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-semibold mb-2">Your Boards</h2>
+      {/* Board list will be rendered here */}
+    </div>
+  );
+}

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export { handler as GET, handler as POST } from '@/lib/auth';

--- a/app/api/boards/[boardId]/lists/route.ts
+++ b/app/api/boards/[boardId]/lists/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { listSchema } from '@/lib/zod';
+
+interface Context { params: { boardId: string } }
+
+export async function POST(req: Request, ctx: Context) {
+  const body = await req.json();
+  const parse = listSchema.safeParse(body);
+  if (!parse.success) return NextResponse.json(parse.error, { status: 400 });
+  const list = await db.list.create({
+    data: { ...parse.data, boardId: ctx.params.boardId }
+  });
+  return NextResponse.json(list, { status: 201 });
+}

--- a/app/api/boards/[boardId]/route.ts
+++ b/app/api/boards/[boardId]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { boardSchema } from '@/lib/zod';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+interface Context {
+  params: { boardId: string };
+}
+
+export async function GET(_req: Request, ctx: Context) {
+  const board = await db.board.findUnique({
+    where: { id: ctx.params.boardId },
+    include: { lists: true }
+  });
+  if (!board) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(board);
+}
+
+export async function PATCH(req: Request, ctx: Context) {
+  const body = await req.json();
+  const parse = boardSchema.partial().safeParse(body);
+  if (!parse.success) return NextResponse.json(parse.error, { status: 400 });
+  const board = await db.board.update({
+    where: { id: ctx.params.boardId },
+    data: parse.data
+  });
+  return NextResponse.json(board);
+}
+
+export async function DELETE(_req: Request, ctx: Context) {
+  await db.board.delete({ where: { id: ctx.params.boardId } });
+  return NextResponse.json({});
+}

--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { boardSchema } from '@/lib/zod';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) return NextResponse.json([], { status: 401 });
+  const boards = await db.board.findMany({
+    where: {
+      members: { some: { user: { email: session.user.email } } }
+    }
+  });
+  return NextResponse.json(boards);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const body = await req.json();
+  const parse = boardSchema.safeParse(body);
+  if (!parse.success) return NextResponse.json(parse.error, { status: 400 });
+  const board = await db.board.create({
+    data: {
+      title: parse.data.title,
+      imageUrl: parse.data.imageUrl,
+      members: {
+        create: { user: { connect: { email: session.user.email } } }
+      }
+    }
+  });
+  return NextResponse.json(board, { status: 201 });
+}

--- a/app/api/cards/[cardId]/route.ts
+++ b/app/api/cards/[cardId]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { cardSchema } from '@/lib/zod';
+
+interface Context { params: { cardId: string } }
+
+export async function GET(_req: Request, ctx: Context) {
+  const card = await db.card.findUnique({
+    where: { id: ctx.params.cardId },
+    include: { comments: true, activities: true }
+  });
+  if (!card) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(card);
+}
+
+export async function PATCH(req: Request, ctx: Context) {
+  const body = await req.json();
+  const parse = cardSchema.partial().safeParse(body);
+  if (!parse.success) return NextResponse.json(parse.error, { status: 400 });
+  const card = await db.card.update({ where: { id: ctx.params.cardId }, data: parse.data });
+  return NextResponse.json(card);
+}
+
+export async function DELETE(_req: Request, ctx: Context) {
+  await db.card.delete({ where: { id: ctx.params.cardId } });
+  return NextResponse.json({});
+}

--- a/app/api/lists/[listId]/cards/route.ts
+++ b/app/api/lists/[listId]/cards/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { cardSchema } from '@/lib/zod';
+
+interface Context { params: { listId: string } }
+
+export async function POST(req: Request, ctx: Context) {
+  const body = await req.json();
+  const parse = cardSchema.safeParse(body);
+  if (!parse.success) return NextResponse.json(parse.error, { status: 400 });
+  const card = await db.card.create({ data: { ...parse.data, listId: ctx.params.listId } });
+  return NextResponse.json(card, { status: 201 });
+}

--- a/app/api/lists/[listId]/route.ts
+++ b/app/api/lists/[listId]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { listSchema } from '@/lib/zod';
+
+interface Context { params: { listId: string } }
+
+export async function PATCH(req: Request, ctx: Context) {
+  const body = await req.json();
+  const parse = listSchema.partial().safeParse(body);
+  if (!parse.success) return NextResponse.json(parse.error, { status: 400 });
+  const list = await db.list.update({ where: { id: ctx.params.listId }, data: parse.data });
+  return NextResponse.json(list);
+}
+
+export async function DELETE(_req: Request, ctx: Context) {
+  await db.list.delete({ where: { id: ctx.params.listId } });
+  return NextResponse.json({});
+}

--- a/app/api/realtime/route.ts
+++ b/app/api/realtime/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from 'next/server';
+import { initSocket } from '@/lib/socket';
+
+export const config = {
+  runtime: 'edge'
+};
+
+export default async function handler(req: NextRequest) {
+  if (!req.socket?.server.io) {
+    initSocket(req.socket.server);
+  }
+  return new Response(null, { status: 200 });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'TaskFlow',
+  description: 'Trello clone built with Next.js 14'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-100">{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <main className="flex flex-col items-center justify-center py-24">
+      <h1 className="text-4xl font-bold mb-4">Welcome to TaskFlow</h1>
+      <p className="text-gray-700">A Trello-like Kanban board application.</p>
+    </main>
+  );
+}

--- a/components/auth/SignInForm.tsx
+++ b/components/auth/SignInForm.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { signIn } from 'next-auth/react';
+import { Button } from '../ui/Button';
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6)
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function SignInForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (data: FormData) => {
+    await signIn('credentials', { ...data, callbackUrl: '/dashboard' });
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div>
+        <input
+          type="email"
+          {...register('email')}
+          placeholder="Email"
+          className="border p-2 w-full"
+        />
+        {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+      </div>
+      <div>
+        <input
+          type="password"
+          {...register('password')}
+          placeholder="Password"
+          className="border p-2 w-full"
+        />
+        {errors.password && <p className="text-red-500 text-sm">{errors.password.message}</p>}
+      </div>
+      <Button type="submit">Sign In</Button>
+    </form>
+  );
+}

--- a/components/board/Card.tsx
+++ b/components/board/Card.tsx
@@ -1,0 +1,11 @@
+interface CardProps {
+  title: string;
+}
+
+export function Card({ title }: CardProps) {
+  return (
+    <div className="bg-white rounded shadow p-2 mb-2">
+      {title}
+    </div>
+  );
+}

--- a/components/board/List.tsx
+++ b/components/board/List.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+
+interface ListProps {
+  title: string;
+  children?: ReactNode;
+}
+
+export function List({ title, children }: ListProps) {
+  return (
+    <div className="bg-gray-100 rounded p-2 w-64">
+      <h3 className="font-semibold mb-2">{title}</h3>
+      {children}
+    </div>
+  );
+}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,15 @@
+import { ButtonHTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+}
+
+export function Button({ variant = 'primary', className, ...props }: ButtonProps) {
+  const base = 'px-4 py-2 rounded';
+  const variants = {
+    primary: 'bg-blue-600 text-white hover:bg-blue-700',
+    secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300'
+  };
+  return <button className={clsx(base, variants[variant], className)} {...props} />;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: taskflow
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: taskflow
+    ports:
+      - '5432:5432'
+    volumes:
+      - db_data:/var/lib/postgresql/data
+volumes:
+  db_data:

--- a/hooks/use-socket.ts
+++ b/hooks/use-socket.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { io, Socket } from 'socket.io-client';
+
+let socket: Socket | null = null;
+
+export function useSocket(url: string) {
+  useEffect(() => {
+    socket = io(url);
+    return () => {
+      socket?.disconnect();
+    };
+  }, [url]);
+  return socket;
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,34 @@
+import NextAuth from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+import GitHubProvider from 'next-auth/providers/github';
+import GoogleProvider from 'next-auth/providers/google';
+
+export const authOptions = {
+  providers: [
+    GitHubProvider({
+      clientId: process.env.GITHUB_ID || '',
+      clientSecret: process.env.GITHUB_SECRET || ''
+    }),
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID || '',
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET || ''
+    }),
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' }
+      },
+      async authorize(credentials) {
+        // TODO: verify credentials
+        return null;
+      }
+    })
+  ],
+  session: { strategy: 'jwt' },
+  secret: process.env.NEXTAUTH_SECRET
+};
+
+export const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from '@prisma/client';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+export const db = global.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') global.prisma = db;

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -1,0 +1,16 @@
+import { Server } from 'socket.io';
+import type { Server as HTTPServer } from 'http';
+
+let io: Server | null = null;
+
+export function initSocket(server: HTTPServer) {
+  if (!io) {
+    io = new Server(server);
+  }
+  return io;
+}
+
+export function getIO() {
+  if (!io) throw new Error('Socket.io not initialized');
+  return io;
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface BoardState {
+  boards: any[];
+  setBoards: (boards: any[]) => void;
+}
+
+export const useBoardStore = create<BoardState>((set) => ({
+  boards: [],
+  setBoards: (boards) => set({ boards })
+}));

--- a/lib/zod.ts
+++ b/lib/zod.ts
@@ -1,0 +1,17 @@
+import * as z from 'zod';
+
+export const boardSchema = z.object({
+  title: z.string().min(1),
+  imageUrl: z.string().url().optional()
+});
+
+export const listSchema = z.object({
+  title: z.string().min(1),
+  order: z.number()
+});
+
+export const cardSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  order: z.number()
+});

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "taskflow",
+  "version": "1.0.0",
+  "description": "TaskFlow - Trello clone",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "next-auth": "^4.24.6",
+    "@prisma/client": "^5.0.0",
+    "prisma": "^5.0.0",
+    "zustand": "^4.3.7",
+    "@dnd-kit/core": "^6.0.6",
+    "@dnd-kit/sortable": "^6.0.6",
+    "socket.io": "^4.7.2",
+    "socket.io-client": "^4.7.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "tailwindcss": "^3.3.3",
+    "postcss": "^8.4.25",
+    "autoprefixer": "^10.4.14"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,123 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id            String   @id @default(cuid())
+  name          String?
+  email         String   @unique
+  emailVerified DateTime?
+  image         String?
+  password      String?
+  accounts      Account[]
+  sessions      Session[]
+  boards        BoardMembership[]
+  cardAssignments CardAssignment[]
+}
+
+model Account {
+  id                String  @id @default(cuid())
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String?
+  access_token      String?
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String?
+  session_state     String?
+  user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+}
+
+model Board {
+  id        String   @id @default(cuid())
+  title     String
+  imageUrl  String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  lists     List[]
+  members   BoardMembership[]
+}
+
+model BoardMembership {
+  boardId String
+  userId  String
+  board   Board @relation(fields: [boardId], references: [id], onDelete: Cascade)
+  user    User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([boardId, userId])
+}
+
+model List {
+  id      String @id @default(cuid())
+  title   String
+  order   Int
+  boardId String
+  board   Board  @relation(fields: [boardId], references: [id], onDelete: Cascade)
+  cards   Card[]
+}
+
+model Card {
+  id          String           @id @default(cuid())
+  title       String
+  description String?
+  order       Int
+  listId      String
+  list        List             @relation(fields: [listId], references: [id], onDelete: Cascade)
+  assignments CardAssignment[]
+  comments    Comment[]
+  activities  Activity[]
+}
+
+model CardAssignment {
+  cardId String
+  userId String
+  card   Card @relation(fields: [cardId], references: [id], onDelete: Cascade)
+  user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([cardId, userId])
+}
+
+model Comment {
+  id        String   @id @default(cuid())
+  content   String
+  createdAt DateTime @default(now())
+  cardId    String
+  userId    String
+  card      Card     @relation(fields: [cardId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model Activity {
+  id        String   @id @default(cuid())
+  text      String
+  createdAt DateTime @default(now())
+  cardId    String
+  userId    String
+  card      Card @relation(fields: [cardId], references: [id], onDelete: Cascade)
+  user      User @relation(fields: [userId], references: [id], onDelete: Cascade)
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": [
+      "node"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 project with TypeScript and Tailwind
- add Prisma schema for boards, lists and cards
- set up NextAuth and Socket.io helpers
- create API route stubs for boards, lists and cards
- add simple UI components and pages
- provide Docker Compose for PostgreSQL

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6848785985b4832e95f72dece35c7dec